### PR TITLE
Phase-4: OPG execution sim + paper routing (v1.2 rules frozen)

### DIFF
--- a/nbsi/phase4/configs/config.yaml
+++ b/nbsi/phase4/configs/config.yaml
@@ -1,0 +1,36 @@
+# Phase-4 execution sim and paper routing config (v1.2 rules frozen)
+# - Execution: 100% next-open via Alpaca OPG
+# - Holdings cadence: strict 2-day; portfolio: 3L/3S
+# - Risk caps: 30% per-sector, 150% gross, 5% daily stop
+# - CT=ET-1 alignment; signals stamped ~15:15 ET; orders queued for next open
+
+inputs:
+  # Prefer Phase-3 winner artifacts
+  base_dir: artifacts/phase3
+  positions_path: null  # e.g., artifacts/phase3/rank_entropy/positions.parquet
+  sector_panel_path: null
+  phase0_price_health: artifacts/phase0/price_health.parquet
+
+broker:
+  name: alpaca
+  paper: true
+  # Keys are read from env: ALPACA_KEY_ID / ALPACA_SECRET_KEY first, then secrets.yaml fallback
+  endpoint: https://paper-api.alpaca.markets
+
+safety:
+  dry_run: true
+  max_order_notional_per_symbol: 10000.0
+  global_kill_switch: false
+
+risk_caps:
+  per_sector: 0.30
+  gross: 1.50
+  daily_stop: 0.05
+
+outputs:
+  base_dir: artifacts/phase4
+  fills: artifacts/phase4/fills.parquet
+  pnl_by_day: artifacts/phase4/pnl_by_day.parquet
+  exec_summary: artifacts/phase4/exec_summary.json
+  qa_log: artifacts/phase4/qa_phase4.log
+

--- a/nbsi/phase4/exec/alpaca_router.py
+++ b/nbsi/phase4/exec/alpaca_router.py
@@ -1,0 +1,55 @@
+"""
+Phase-4 Alpaca paper broker router (scaffold).
+- Builds OPG orders for t+1, batch submit when dry_run=False.
+- Reads keys from env (ALPACA_KEY_ID / ALPACA_SECRET_KEY) first; then optional secrets.yaml fallback.
+- For scaffolding, we log intents; no live submissions are performed by default (dry_run=True).
+"""
+from __future__ import annotations
+import os
+from pathlib import Path
+from typing import Dict, Any, List
+
+
+def load_secrets_from_yaml(path: Path) -> Dict[str, str]:
+    try:
+        import yaml  # type: ignore
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        return {str(k): str(v) for k, v in (data or {}).items()}
+    except Exception:
+        return {}
+
+
+def get_alpaca_keys() -> Dict[str, str]:
+    key = os.getenv("ALPACA_KEY_ID")
+    secret = os.getenv("ALPACA_SECRET_KEY")
+    if key and secret:
+        return {"key_id": key, "secret_key": secret}
+    # fallback to secrets.yaml if present
+    secrets_path = Path("secrets.yaml")
+    if secrets_path.exists():
+        sec = load_secrets_from_yaml(secrets_path)
+        if "ALPACA_KEY_ID" in sec and "ALPACA_SECRET_KEY" in sec:
+            return {"key_id": sec["ALPACA_KEY_ID"], "secret_key": sec["ALPACA_SECRET_KEY"]}
+    return {"key_id": "", "secret_key": ""}
+
+
+def build_opg_orders(intents: List[Dict[str, Any]], dry_run: bool = True) -> Dict[str, Any]:
+    """
+    Given a list of order intents like {symbol, side, qty}, produce Alpaca OPG orders payloads.
+    This scaffolding only returns the payloads and logs; no submissions.
+    """
+    orders = []
+    for it in intents:
+        orders.append(
+            {
+                "symbol": it["symbol"],
+                "side": it["side"],
+                "qty": int(it.get("qty", 0)),
+                "type": "market",
+                "time_in_force": "opg",
+                "client_order_id": it.get("client_order_id", None),
+                "extended_hours": False,
+            }
+        )
+    return {"dry_run": dry_run, "orders": orders}
+

--- a/nbsi/phase4/exec/simulator.py
+++ b/nbsi/phase4/exec/simulator.py
@@ -1,0 +1,84 @@
+"""
+Phase-4 execution simulator (OPG) — scaffolding.
+- Simulates next-open fills at t+1 open given signals at t.
+- Enforces v1.2 invariants by interface (no business-rule changes implemented here).
+
+This initial scaffold creates placeholder artifacts so downstream QA/plumbing can run end-to-end.
+"""
+from __future__ import annotations
+import json
+import os
+from pathlib import Path
+from typing import Optional, Dict, Any
+
+
+def ensure_dir(p: Path) -> None:
+    p.mkdir(parents=True, exist_ok=True)
+
+
+def write_text(path: Path, text: str) -> None:
+    ensure_dir(path.parent)
+    path.write_text(text, encoding="utf-8")
+
+
+def write_json(path: Path, data: Dict[str, Any]) -> None:
+    ensure_dir(path.parent)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def write_parquet_placeholder(path: Path) -> None:
+    """
+    Creates a tiny placeholder parquet-like artifact. If pandas/pyarrow is available, write a real parquet
+    with zero rows; otherwise, write a CSV with .parquet extension as a placeholder to keep scaffolding unblocked.
+    """
+    ensure_dir(path.parent)
+    try:
+        import pandas as pd  # type: ignore
+        df = pd.DataFrame([], columns=["date", "symbol", "side", "qty", "price"])  # minimal schema
+        df.to_parquet(path, index=False)
+    except Exception:
+        # Fallback: clearly mark placeholder content
+        path.write_text("placeholder, no rows", encoding="utf-8")
+
+
+def simulate_opg(
+    out_dir: Path,
+    outputs: Dict[str, str],
+    config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """
+    Minimal simulation stub. Produces required artifacts and a summary.
+    """
+    out_dir = Path(out_dir)
+    ensure_dir(out_dir)
+
+    fills_path = Path(outputs.get("fills", out_dir / "fills.parquet"))
+    pnl_path = Path(outputs.get("pnl_by_day", out_dir / "pnl_by_day.parquet"))
+    summary_path = Path(outputs.get("exec_summary", out_dir / "exec_summary.json"))
+
+    write_parquet_placeholder(fills_path)
+    write_parquet_placeholder(pnl_path)
+    summary = {
+        "mode": "simulate",
+        "assumptions": {
+            "opg": True,
+            "two_day_hold": True,
+            "portfolio": "3L/3S",
+            "caps": {"per_sector": 0.30, "gross": 1.50, "daily_stop": 0.05},
+        },
+        "notes": "Phase-4 scaffold — replace with full simulator logic.",
+    }
+    write_json(summary_path, summary)
+    return summary
+
+
+if __name__ == "__main__":
+    # Manual smoke: create placeholders under artifacts/phase4
+    outputs = {
+        "fills": "artifacts/phase4/fills.parquet",
+        "pnl_by_day": "artifacts/phase4/pnl_by_day.parquet",
+        "exec_summary": "artifacts/phase4/exec_summary.json",
+    }
+    sim_summary = simulate_opg(Path("artifacts/phase4"), outputs)
+    print("Sim summary:", sim_summary)
+

--- a/nbsi/phase4/qa/qa_phase4.py
+++ b/nbsi/phase4/qa/qa_phase4.py
@@ -1,0 +1,22 @@
+"""
+Phase-4 QA scaffold.
+- Validates no look-ahead (t -> t+1 OPG), cadence, caps, and stop logic in later iterations.
+- For now, writes a PASS line so pipelines can wire up end-to-end.
+"""
+from __future__ import annotations
+from pathlib import Path
+
+
+def write_pass_log(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        f.write("QA PASS: Phase-4 scaffold checks placeholder.\n")
+
+
+def run_qa(log_path: Path) -> None:
+    write_pass_log(log_path)
+
+
+if __name__ == "__main__":
+    run_qa(Path("artifacts/phase4/qa_phase4.log"))
+

--- a/nbsi/phase4/scripts/run_phase4.py
+++ b/nbsi/phase4/scripts/run_phase4.py
@@ -1,0 +1,52 @@
+"""
+Phase-4 Runner
+Usage examples:
+  python nbsi/phase4/scripts/run_phase4.py --mode simulate --dry-run true --from artifacts/phase3
+  python nbsi/phase4/scripts/run_phase4.py --mode route --dry-run true --from artifacts/phase3
+"""
+from __future__ import annotations
+import argparse
+import sys
+from pathlib import Path
+from typing import Dict, Any
+
+# Ensure repository root is on sys.path when invoked as a script
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from nbsi.phase4.exec.simulator import simulate_opg
+from nbsi.phase4.qa.qa_phase4 import run_qa
+
+
+def load_config(cfg_path: Path) -> Dict[str, Any]:
+    import yaml  # type: ignore
+    return yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mode", choices=["simulate", "route"], required=True)
+    ap.add_argument("--dry-run", choices=["true", "false"], default="true")
+    ap.add_argument("--from", dest="from_path", default="artifacts/phase3")
+    ap.add_argument("--config", default="nbsi/phase4/configs/config.yaml")
+    args = ap.parse_args()
+
+    cfg = load_config(Path(args.config))
+    out_cfg = cfg.get("outputs", {})
+    out_dir = Path(out_cfg.get("base_dir", "artifacts/phase4"))
+
+    if args.mode == "simulate":
+        simulate_opg(out_dir, out_cfg, cfg)
+        # Write QA log (scaffold PASS)
+        run_qa(Path(out_cfg.get("qa_log", out_dir / "qa_phase4.log")))
+        print("PHASE 4 SIM COMPLETE")
+    else:
+        # route (dry) - stub: only logs intents placeholder
+        # In a later iteration, wire signals->intents->alpaca_router.build_opg_orders(...)
+        run_qa(Path(out_cfg.get("qa_log", out_dir / "qa_phase4.log")))
+        print("PHASE 4 ROUTE (DRY) COMPLETE")
+
+
+if __name__ == "__main__":
+    main()

--- a/nbsi/phase4/tests/test_opg_timing.py
+++ b/nbsi/phase4/tests/test_opg_timing.py
@@ -1,0 +1,7 @@
+import unittest
+
+@unittest.skip("Phase-4 scaffold: timing check to be implemented")
+class TestOPGTiming(unittest.TestCase):
+    def test_labels_are_t_plus_1_open_close(self):
+        self.assertTrue(True)
+

--- a/nbsi/phase4/tests/test_risk_caps.py
+++ b/nbsi/phase4/tests/test_risk_caps.py
@@ -1,0 +1,10 @@
+import unittest
+
+@unittest.skip("Phase-4 scaffold: risk caps check to be implemented")
+class TestRiskCaps(unittest.TestCase):
+    def test_sector_and_gross_caps(self):
+        self.assertTrue(True)
+
+    def test_two_day_cadence(self):
+        self.assertTrue(True)
+

--- a/nbsi/phase4/tests/test_stop_flatten.py
+++ b/nbsi/phase4/tests/test_stop_flatten.py
@@ -1,0 +1,7 @@
+import unittest
+
+@unittest.skip("Phase-4 scaffold: daily stop flatten check to be implemented")
+class TestStopFlatten(unittest.TestCase):
+    def test_stop_triggers_flatten(self):
+        self.assertTrue(True)
+


### PR DESCRIPTION
Adds Phase-4 scaffold: configs, exec simulator (OPG), paper router stub, QA, runner, and tests (initially skipped).
v1.2 rules unchanged: 2-day cadence; 3L/3S; caps 30% sector / 150% gross; 5% daily stop; 100% next-open (OPG); CT=ET−1 alignment; no look-ahead.