### PR TITLE
Phase-4: add --emit-csv option to write orders_intents.csv

### DIFF
--- a/nbsi/phase4/scripts/run_phase4.py
+++ b/nbsi/phase4/scripts/run_phase4.py
@@ -116,9 +116,23 @@ def main_route(args) -> None:
     )
 
     intents_path = os.path.join(out_dir, "orders_intents.parquet")
-    intents.to_parquet(intents_path)
+    intents.to_parquet(intents_path, index=False)
 
-    with open(os.path.join(out_dir, "qa_phase4.log"), "a", encoding="utf-8") as f:
+    # Optional CSV emission for quick eyeballing
+    emit_csv = str(getattr(args, "emit_csv", "false")).lower() in {"1","true","yes","y"}
+    qa_path = os.path.join(out_dir, "qa_phase4.log")
+    if emit_csv:
+        csv_path = os.path.join(out_dir, "orders_intents.csv")
+        intents.to_csv(csv_path, index=False)
+        with open(qa_path, "a", encoding="utf-8") as f:
+            f.write(f"[route] emitted CSV: {os.path.relpath(csv_path)} rows={len(intents)}\n")
+    else:
+        with open(qa_path, "a", encoding="utf-8") as f:
+            f.write(f"[route] parquet only: {os.path.relpath(intents_path)} rows={len(intents)}\n")
+
+
+    # Keep legacy pass line for continuity
+    with open(qa_path, "a", encoding="utf-8") as f:
         f.write(f"ROUTING DRY PASS: wrote {len(intents)} intents to {intents_path}\n")
 
     print("PHASE 4 ROUTE (DRY) COMPLETE")
@@ -130,6 +144,8 @@ def main() -> None:
     ap.add_argument("--dry-run", choices=["true", "false"], default="true")
     ap.add_argument("--from", dest="from_path", default="artifacts/phase3")
     ap.add_argument("--config", default="nbsi/phase4/configs/config.yaml")
+    ap.add_argument("--emit-csv", default="false",
+                    help="Also write orders_intents.csv beside parquet (true/false). Default false.")
     args = ap.parse_args()
 
     if args.mode == "simulate":


### PR DESCRIPTION
Tiny UX improvement for quick eyeballing; off by default; writes CSV alongside parquet and logs note in QA; no secrets/network.