### PR TITLE
 Phase-4: add unit test for --emit-csv (temp artifacts via NBSI_OUT_ROOT)

### DIFF
--- a/nbsi/phase4/scripts/run_phase4.py
+++ b/nbsi/phase4/scripts/run_phase4.py
@@ -51,7 +51,8 @@ def _load_prices(p3_path: str) -> tuple[pd.DataFrame, pd.DataFrame]:
 
 def main_simulate(args) -> None:
     base = args.from_path or "artifacts/phase3"
-    out_dir = "artifacts/phase4"
+    out_root = os.getenv("NBSI_OUT_ROOT", "")
+    out_dir = os.path.join(out_root, "artifacts", "phase4") if out_root else os.path.join("artifacts", "phase4")
     os.makedirs(out_dir, exist_ok=True)
 
     scores = _load_scores(os.path.join("artifacts", "phase2"))
@@ -94,7 +95,8 @@ def main_simulate(args) -> None:
 
 
 def main_route(args) -> None:
-    out_dir = "artifacts/phase4"
+    out_root = os.getenv("NBSI_OUT_ROOT", "")
+    out_dir = os.path.join(out_root, "artifacts", "phase4") if out_root else os.path.join("artifacts", "phase4")
     pos_path = os.path.join(out_dir, "positions_effective.parquet")
     if not os.path.exists(pos_path):
         raise FileNotFoundError(
@@ -116,9 +118,20 @@ def main_route(args) -> None:
     )
 
     intents_path = os.path.join(out_dir, "orders_intents.parquet")
-    intents.to_parquet(intents_path)
+    intents.to_parquet(intents_path, index=False)
 
-    with open(os.path.join(out_dir, "qa_phase4.log"), "a", encoding="utf-8") as f:
+    qa_path = os.path.join(out_dir, "qa_phase4.log")
+    emit_csv = str(getattr(args, "emit_csv", "false")).lower() in {"1","true","yes","y"}
+    if emit_csv:
+        csv_path = os.path.join(out_dir, "orders_intents.csv")
+        intents.to_csv(csv_path, index=False)
+        with open(qa_path, "a", encoding="utf-8") as f:
+            f.write(f"[route] emitted CSV: {os.path.relpath(csv_path)} rows={len(intents)}\n")
+    else:
+        with open(qa_path, "a", encoding="utf-8") as f:
+            f.write(f"[route] parquet only: {os.path.relpath(intents_path)} rows={len(intents)}\n")
+
+    with open(qa_path, "a", encoding="utf-8") as f:
         f.write(f"ROUTING DRY PASS: wrote {len(intents)} intents to {intents_path}\n")
 
     print("PHASE 4 ROUTE (DRY) COMPLETE")
@@ -130,6 +143,8 @@ def main() -> None:
     ap.add_argument("--dry-run", choices=["true", "false"], default="true")
     ap.add_argument("--from", dest="from_path", default="artifacts/phase3")
     ap.add_argument("--config", default="nbsi/phase4/configs/config.yaml")
+    ap.add_argument("--emit-csv", default="false",
+                    help="Also write orders_intents.csv beside parquet (true/false). Default false.")
     args = ap.parse_args()
 
     if args.mode == "simulate":

--- a/nbsi/phase4/tests/test_emit_csv.py
+++ b/nbsi/phase4/tests/test_emit_csv.py
@@ -1,0 +1,63 @@
+import os, sys, subprocess, unittest
+from pathlib import Path
+import pandas as pd
+
+
+def _write_positions_effective(root: Path):
+    # Minimal two-day positions so router has something to diff.
+    df = pd.DataFrame({
+        "date_et": pd.to_datetime(["2025-07-08", "2025-07-09"]),
+        "XLB": [ 0.25,  0.10],
+        "XLC": [ 0.25,  0.25],
+        "XLE": [ 0.25,  0.35],
+        "XLU": [-0.25, -0.15],
+        "XLV": [-0.25, -0.25],
+        "XLY": [-0.25, -0.30],
+    })
+    (root / "artifacts" / "phase4").mkdir(parents=True, exist_ok=True)
+    df.to_parquet(root / "artifacts" / "phase4" / "positions_effective.parquet", index=False)
+
+
+class TestEmitCSV(unittest.TestCase):
+    def test_route_emits_csv(self):
+        tmp_path = Path.cwd() / "_tmp_emit_csv"
+        if tmp_path.exists():
+            # clean up from previous runs
+            for p in sorted(tmp_path.rglob("*"), reverse=True):
+                try:
+                    p.unlink()
+                except IsADirectoryError:
+                    pass
+        tmp_path.mkdir(parents=True, exist_ok=True)
+
+        repo_root = Path(__file__).resolve().parents[3]  # project root
+        _write_positions_effective(tmp_path)
+
+        script = repo_root / "nbsi" / "phase4" / "scripts" / "run_phase4.py"
+        cmd = [
+            sys.executable, str(script),
+            "--mode", "route",
+            "--dry-run", "true",
+            "--from", str(tmp_path / "artifacts" / "phase3"),
+            "--emit-csv", "true",
+        ]
+        env = os.environ.copy()
+        env["NBSI_OUT_ROOT"] = str(tmp_path)
+        subprocess.check_call(cmd, cwd=repo_root, env=env)
+
+        csv_path = tmp_path / "artifacts" / "phase4" / "orders_intents.csv"
+        pq_path  = tmp_path / "artifacts" / "phase4" / "orders_intents.parquet"
+        qa_path  = tmp_path / "artifacts" / "phase4" / "qa_phase4.log"
+
+        self.assertTrue(csv_path.exists(), "orders_intents.csv was not written")
+        self.assertTrue(pq_path.exists(),  "orders_intents.parquet was not written")
+        df_csv = pd.read_csv(csv_path)
+        self.assertGreater(len(df_csv), 0, "CSV should have at least one intent row")
+        self.assertTrue(qa_path.exists())
+        qa_txt = qa_path.read_text(encoding="utf-8", errors="ignore")
+        self.assertIn("emitted CSV", qa_txt)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
Adds a hermetic unittest that fabricates positions_effective, routes with --emit-csv true, and asserts CSV + QA log creation. Also teaches the runner to honor NBSI_OUT_ROOT so the test runs in a temp dir (no secrets, no network).