### PR TITLE
Chore: rotate Phase-5 QA log before each run (keep .1..7)

### DIFF
--- a/scripts/rotate_log.cmd
+++ b/scripts/rotate_log.cmd
@@ -1,0 +1,13 @@
+@echo off
+setlocal
+set "LOG=%~1"
+if "%LOG%"=="" goto :eof
+
+REM Rotate qa_phase5.log -> qa_phase5.log.1 ... qa_phase5.log.7 (oldest dropped)
+for /L %%i in (7,-1,2) do (
+  if exist "%LOG%.%%i-1" ren "%LOG%.%%i-1" "%~nx1.%%i"
+)
+if exist "%LOG%" ren "%LOG%" "%~nx1.1"
+
+endlocal
+

--- a/scripts/run_phase5_report.cmd
+++ b/scripts/run_phase5_report.cmd
@@ -16,7 +16,12 @@ set "NBSI_OUT_ROOT=%REPO%"
 
 REM Run Phase-5 report (no network; reads Phase-4/Phase-3 artifacts)
 cd /d "%REPO%"
-py -3.11 nbsi\phase5\scripts\run_phase5.py --from "%PHASE4%" --out "%OUT%" --phase3-root "%PHASE3%" >> "%OUT%\qa_phase5.log" 2>&1
+
+REM Rotate Phase-5 QA log before each run (keeps .1..7)
+set "LOG=%OUT%\qa_phase5.log"
+if exist "%REPO%\scripts\rotate_log.cmd" call "%REPO%\scripts\rotate_log.cmd" "%LOG%"
+
+python nbsi\phase5\scripts\run_phase5.py --from "%PHASE4%" --out "%OUT%" --phase3-root "%PHASE3%"
 
 exit /b %ERRORLEVEL%
 


### PR DESCRIPTION
Adds scripts/rotate_log.cmd and rotates artifacts/phase5/qa_phase5.log before report; Windows-only helper; no logic changes.