### PR TITLE
Phase-4: simulate QA provenance + runbook Start In reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,6 @@ Outputs:
 - Business rules remain frozen (v1.2): 2-day hold, 3L/3S, sector ≤30%, gross ≤150%, 5% daily stop, OPG timing.
 - `NBSI_OUT_ROOT` is honored by all scripts if set.
 - For safety, the submit path refuses without `--confirm "I UNDERSTAND"` and valid env creds.
+
+
+**Start In (Task Scheduler):** set to `D:\Ticker Tattle` to avoid relative-path issues when the job runs headless.

--- a/nbsi/phase4/scripts/run_phase4.py
+++ b/nbsi/phase4/scripts/run_phase4.py
@@ -90,9 +90,15 @@ def main_simulate(args) -> None:
         json.dump(summary, f, indent=2)
 
     qa = os.path.join(out_dir, "qa_phase4.log")
-    with open(qa, "w", encoding="utf-8") as f:
+    # --- run banner + provenance (parity with route path) ---
+    with open(qa, "a", encoding="utf-8") as f:
+        f.write(f"--- run {datetime.now().isoformat(timespec='seconds')} ---\n")
+        f.write(f"provenance: host={platform.node()} user={getpass.getuser()}\n")
+    # QA summary and completion line
+    with open(qa, "a", encoding="utf-8") as f:
         f.write("QA PASS: positions aligned t->t+1, caps applied, stop applied\n")
         f.write(repr(summary) + "\n")
+        f.write("PHASE 4 SIM COMPLETE\n")
 
     print("PHASE 4 SIM COMPLETE")
 


### PR DESCRIPTION
Adds run banner + host/user provenance to Phase‑4 simulate QA (parity with route). README gets a one-line Task Scheduler “Start In” tip. No logic changes; no network.